### PR TITLE
add MTI gem and first two models with migrations

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -30,6 +30,9 @@ gem 'omniauth'
 gem 'omniauth-github'
 gem 'omniauth-rails_csrf_protection', '~> 0.1'
 
+# Multiple Table Inheritance
+gem 'active_record-acts_as'
+
 # Manage .env variables
 gem 'dotenv-rails'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -37,6 +37,9 @@ GEM
       erubi (~> 1.4)
       rails-dom-testing (~> 2.0)
       rails-html-sanitizer (~> 1.1, >= 1.2.0)
+    active_record-acts_as (4.0.1)
+      activerecord (>= 4.2)
+      activesupport (>= 4.2)
     activejob (6.0.0)
       activesupport (= 6.0.0)
       globalid (>= 0.3.6)
@@ -229,6 +232,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  active_record-acts_as
   bootsnap (>= 1.4.2)
   byebug
   capybara (>= 2.15)

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ JOT is an open source project to aggregate all your disaggregated work items (i.
 
 * [Dependencies](#dependencies)
 * [Installation and Usage](#installation-and-usage)
-* [Contributin](#contributing)
+* [Contributing](#contributing)
 * [License](#license)
 
 ## Dependencies

--- a/app/models/github_item.rb
+++ b/app/models/github_item.rb
@@ -1,0 +1,3 @@
+class GithubItem < ApplicationRecord
+  acts_as :item
+end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -1,0 +1,3 @@
+class Item < ApplicationRecord
+  actable
+end

--- a/db/migrate/20191027115757_create_items.rb
+++ b/db/migrate/20191027115757_create_items.rb
@@ -1,0 +1,12 @@
+class CreateItems < ActiveRecord::Migration[6.0]
+  def change
+    create_table :items do |t|
+      t.string :title
+      t.string :state
+      t.string :source_url
+      t.integer :assignee_id
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20191027122801_add_actable_to_items.rb
+++ b/db/migrate/20191027122801_add_actable_to_items.rb
@@ -1,0 +1,7 @@
+class AddActableToItems < ActiveRecord::Migration[6.0]
+  def change
+    change_table :items do |t|
+      t.actable
+    end
+  end
+end

--- a/db/migrate/20191027123021_create_github_items.rb
+++ b/db/migrate/20191027123021_create_github_items.rb
@@ -1,0 +1,7 @@
+class CreateGithubItems < ActiveRecord::Migration[6.0]
+  def change
+    create_table :github_items do |t|
+      t.string :repo_url
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,26 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_10_27_062118) do
+ActiveRecord::Schema.define(version: 2019_10_27_123021) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "github_items", force: :cascade do |t|
+    t.string "repo_url"
+  end
+
+  create_table "items", force: :cascade do |t|
+    t.string "title"
+    t.string "state"
+    t.string "source_url"
+    t.integer "assignee_id"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.string "actable_type"
+    t.bigint "actable_id"
+    t.index ["actable_type", "actable_id"], name: "index_items_on_actable_type_and_actable_id"
+  end
 
   create_table "users", force: :cascade do |t|
     t.string "provider"

--- a/test/fixtures/github_items.yml
+++ b/test/fixtures/github_items.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+# This model initially had no columns defined. If you add columns to the
+# model remove the '{}' from the fixture names and add the columns immediately
+# below each fixture, per the syntax in the comments below
+#
+one: {}
+# column: value
+#
+two: {}
+# column: value

--- a/test/fixtures/items.yml
+++ b/test/fixtures/items.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+# This model initially had no columns defined. If you add columns to the
+# model remove the '{}' from the fixture names and add the columns immediately
+# below each fixture, per the syntax in the comments below
+#
+one: {}
+# column: value
+#
+two: {}
+# column: value

--- a/test/models/github_item_test.rb
+++ b/test/models/github_item_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class GithubItemTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/models/item_test.rb
+++ b/test/models/item_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class ItemTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
Add gem to manage multiple-table inheritance so subclass models can inherit from superclass model and created first two models (`Item` and `GithubItem`). 